### PR TITLE
fix: Auto Y reply not working properly for accepting android licenses

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -7,7 +7,7 @@ tasks:
 
       flutter config --enable-web
       flutter config --android-sdk /home/gitpod/androidsdk
-      echo y | flutter doctor --android-licenses
+      yes | flutter doctor --android-licenses
 
       flutter doctor
 


### PR DESCRIPTION
## Description
Auyomated Y input into `flutter doctor --android-licenses` does not work and this should resolve it.

## Related Issue(s)
Someone mentioned this issue at the [Discord](https://discord.com/channels/816244985187008514/893080924428836865/893098995411451914) server