### PR TITLE
fix(web): Allocate 4GB shmem to avoid google-chrome crash

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,6 +1,7 @@
 image:
   file: .gitpod.Dockerfile
 tasks:
+  - before: sudo mount -t tmpfs shm -osize=4096m /dev/shm
   - init: |
       flutter channel beta
       flutter upgrade


### PR DESCRIPTION
## Description
Google chrome internally crashes with a "Aw snap!" page every time it tries to load a slightly memory hungry webpage, this is happening because of the small size of `/dev/shm` (shared memory). It seems to be mounted with 64MB limit by default.

I came across two solutions:
- Wrapping `google-chrome` binary via a shell script to pass `-disabled-dev-shm-usage` into the original binary. Although this is a complicated solution and might not be future-proof or resource-efficient.
- Just overlapping the `/dev/shm` with a tmpfs mount fixed to 4GB size, I would have tried remounting the existing `/dev/shm` mountpoint with a new size but probably due to security reasons this isn't allowed. This is my proposed solution.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Not a Github issue but on [Discord](https://discord.com/channels/816244985187008514/816246578594840586/920628884205097001)

## How to test
<!-- Provide steps to test this PR -->
- Open this PR in Gitpod.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
flutter-web chrome browser no longer crashes
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
No change required.