### PR TITLE
Update: add `--web-hostname=0.0.0.0` and `-d web-server` options in the `flutter run` command, so that the sample program can be opened normally.

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -57,7 +57,7 @@ tasks:
 
       flutter devices
     
-      flutter run --web-port 8080
+      flutter run -d web-server --web-port=8080 --web-hostname=0.0.0.0
 
 
 ports:


### PR DESCRIPTION
## Description

Use

```bash
flutter run -d web-server --web-port=8080 --web-hostname=0.0.0.0
```

Instead of 

```bash
flutter run --web-port 8080
```


## Related Issue(s)
NONE

## How to test
Just start a new workspace, wait for flutter run and the internal web browser will reload automatically.

## Release Notes
NONE


## Documentation
No

