### PR TITLE
Fix: App cannot opened normally in web browser when `flutter run` not explicitly specify hostname as 0.0.0.0

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -57,7 +57,7 @@ tasks:
 
       flutter devices
     
-      flutter run --web-port 8080
+      flutter run -d web-server --web-port=8080 --web-hostname=0.0.0.0
 
 
 ports:


### PR DESCRIPTION
Fix: App cannot opened normally in web browser.

Use

```bash
flutter run -d web-server --web-port=8080 --web-hostname=0.0.0.0
```

Instead of 

```bash
flutter run --web-port 8080
```


## Related Issue(s)
NONE

## How to test
Just start a new workspace, wait for flutter run and the internal web browser will reload automatically.

## Release Notes
NONE


## Documentation
No
<img width="1190" alt="WX20220122-010618@2x" src="https://user-images.githubusercontent.com/23764/150569538-d9424da5-c2f5-4f06-b354-a3093aba0d31.png">

