### PR TITLE
added chrome gpg to .gitpod.Dockerfile

### DIFF
--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -7,6 +7,10 @@ ENV PATH="$HOME/flutter/bin:$ANDROID_HOME/emulator:$ANDROID_HOME/tools:$ANDROID_
 
 # Install Open JDK for android and other dependencies
 USER root
+
+# Add Google Chrome repository key
+RUN wget -q -O - https://dl.google.com/linux/linux_signing_key.pub | apt-key add -
+
 RUN install-packages openjdk-8-jdk -y \
         libgtk-3-dev \
         libnss3-dev \


### PR DESCRIPTION
the image fails to be built from a forked or "use as template" repository , adding google chrome key to the docker file solves it.